### PR TITLE
Allow configuration of which HTTP methods to cache and replay.

### DIFF
--- a/idempotency_header_middleware/middleware.py
+++ b/idempotency_header_middleware/middleware.py
@@ -1,8 +1,8 @@
 import json
 from collections import namedtuple
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from json import JSONDecodeError
-from typing import Any, Union
+from typing import Any, List, Union
 from uuid import UUID
 
 from starlette.datastructures import Headers
@@ -29,12 +29,13 @@ class IdempotencyHeaderMiddleware:
     idempotency_header_key: str = 'Idempotency-Key'
     replay_header_key: str = 'Idempotent-Replayed'
     enforce_uuid4_formatting: bool = False
+    applicable_methods: List[str] = field(default_factory=lambda: ['POST', 'PATCH'])
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> Union[JSONResponse, Any]:
         """
         Enable idempotent operations in POST and PATCH endpoints.
         """
-        if scope['type'] != 'http' or scope['method'] not in ['POST', 'PATCH']:
+        if scope['type'] != 'http' or scope['method'] not in self.applicable_methods:
             return await self.app(scope, receive, send)
 
         request_headers = Headers(scope=scope)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ import pytest
 from fastapi import FastAPI
 from fastapi.responses import ORJSONResponse, UJSONResponse
 from httpx import AsyncClient
-from starlette.middleware import Middleware
 from starlette.responses import (
     FileResponse,
     HTMLResponse,
@@ -26,51 +25,75 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler())
 
-app = FastAPI(
-    middleware=[
-        Middleware(
-            IdempotencyHeaderMiddleware,
-            enforce_uuid4_formatting=True,
-            backend=AioredisBackend(redis=fakeredis.aioredis.FakeRedis(decode_responses=True)),
-        )
-    ]
-)
+app = FastAPI()
+
+method_configs = {
+    'default': {'setting': ['POST', 'PATCH'], 'applicable_methods': ['post', 'patch']},
+    'post only': {'setting': ['POST'], 'applicable_methods': ['post']},
+    'with put': {'setting': ['POST', 'PATCH', 'PUT'], 'applicable_methods': ['post', 'patch', 'put']},
+}
+
+
+@pytest.fixture(scope='session', ids=method_configs.keys(), params=method_configs.values())
+def method_config(request):
+    return request.param
+
+
+@pytest.fixture(scope='session', autouse=True)
+def app_with_middleware(method_config):
+    app.add_middleware(
+        IdempotencyHeaderMiddleware,
+        enforce_uuid4_formatting=True,
+        backend=AioredisBackend(redis=fakeredis.aioredis.FakeRedis(decode_responses=True)),
+        applicable_methods=method_config['setting'],
+    )
+    yield app
+    # Remove the middleware
+    app.user_middleware.pop(0)
+    app.middleware_stack = app.build_middleware_stack()
+
 
 dummy_response = {'test': 'test'}
 
 
 @app.patch('/json-response')
 @app.post('/json-response')
+@app.put('/json-response')
 async def create_json_response() -> JSONResponse:
     return JSONResponse(dummy_response, 201)
 
 
 @app.patch('/dict-response', status_code=201)
 @app.post('/dict-response', status_code=201)
+@app.put('/dict-response', status_code=201)
 async def create_dict_response() -> dict:
     return dummy_response
 
 
 @app.patch('/normal-byte-response')
 @app.post('/normal-byte-response')
+@app.put('/normal-byte-response')
 async def create_normal_byte_response() -> Response:
     return Response(content=json.dumps(dummy_response).encode(), status_code=201)
 
 
 @app.patch('/normal-response', response_class=Response)
 @app.post('/normal-response', response_class=Response)
+@app.put('/normal-response', response_class=Response)
 async def create_normal_response():
     return Response(content=json.dumps(dummy_response), media_type='application/json')
 
 
 @app.patch('/bad-response', response_class=Response)
 @app.post('/bad-response', response_class=Response)
+@app.put('/bad-response', response_class=Response)
 async def create_bad_response():
     return Response(content=json.dumps(dummy_response), media_type='application/xml')
 
 
 @app.patch('/xml-response')
 @app.post('/xml-response')
+@app.put('/xml-response')
 async def create_xml_response():
     data = """<?xml version="1.0"?>
     <shampoo>
@@ -87,18 +110,21 @@ async def create_xml_response():
 
 @app.patch('/orjson-response', response_class=ORJSONResponse)
 @app.post('/orjson-response', response_class=ORJSONResponse)
+@app.put('/orjson-response', response_class=ORJSONResponse)
 async def create_orjson_response():
     return dummy_response
 
 
 @app.patch('/ujson-response', response_class=UJSONResponse)
 @app.post('/ujson-response', response_class=UJSONResponse)
+@app.put('/ujson-response', response_class=UJSONResponse)
 async def create_ujson_response():
     return dummy_response
 
 
 @app.patch('/html-response', response_class=HTMLResponse)
 @app.post('/html-response', response_class=HTMLResponse)
+@app.put('/html-response', response_class=HTMLResponse)
 async def create_html_response():
     return """
     <html>
@@ -114,6 +140,7 @@ async def create_html_response():
 
 @app.patch('/file-response', response_class=FileResponse)
 @app.post('/file-response', response_class=FileResponse)
+@app.put('/file-response', response_class=FileResponse)
 async def create_file_response():
     path = Path(__file__)
     return path.parent / 'static/image.jpeg'
@@ -121,12 +148,14 @@ async def create_file_response():
 
 @app.patch('/plain-text-response', response_class=FileResponse)
 @app.post('/plain-text-response', response_class=FileResponse)
+@app.put('/plain-text-response', response_class=FileResponse)
 async def create_plaintext_response():
     return PlainTextResponse('test')
 
 
 @app.patch('/redirect-response', response_class=FileResponse)
 @app.post('/redirect-response', response_class=FileResponse)
+@app.put('/redirect-response', response_class=FileResponse)
 async def create_redirect_response():
     return RedirectResponse('test')
 
@@ -136,6 +165,7 @@ async def create_redirect_response():
 @app.delete('/idempotent-method', response_class=JSONResponse)
 @app.put('/idempotent-method', response_class=JSONResponse)
 @app.head('/idempotent-method', response_class=JSONResponse)
+@app.patch('/idempotent-method', response_class=JSONResponse)
 async def idempotent_method():
     return Response(status_code=204)
 
@@ -153,6 +183,7 @@ async def fake_video_streamer():
 
 @app.patch('/streaming-response', response_class=FileResponse)
 @app.post('/streaming-response', response_class=FileResponse)
+@app.put('/streaming-response', response_class=FileResponse)
 async def create_streaming_response():
     return StreamingResponse(fake_video_streamer())
 
@@ -168,3 +199,19 @@ def event_loop():
 async def client() -> AsyncClient:
     async with AsyncClient(app=app, base_url='http://test') as client:
         yield client
+
+
+@pytest.fixture(params=['post', 'patch', 'put'])
+def applicable_method(method_config, client, request):
+    if request.param in method_config['applicable_methods']:
+        return client.__getattribute__(request.param)
+    else:
+        raise pytest.skip(request.param + ' is not an applicable method in this configuration.')
+
+
+@pytest.fixture(params=['get', 'delete', 'options', 'head', 'put', 'patch'])
+def inapplicable_method(method_config, client, request):
+    if request.param in method_config['applicable_methods']:
+        raise pytest.skip(request.param + ' is an applicable method in this configuration.')
+    else:
+        return client.__getattribute__(request.param)


### PR DESCRIPTION
In non-RESTful applications, it is useful to allow caching additional HTTP methods beyond `POST` and `PATCH`. This pull request allows passing a list of HTTP method names for which caching and replaying will be enabled.